### PR TITLE
explicitly use Range.new/3 when counting down

### DIFF
--- a/lib/parse/datetime/helpers.ex
+++ b/lib/parse/datetime/helpers.ex
@@ -159,13 +159,13 @@ defmodule Timex.Parse.DateTime.Helpers do
 
     case {padding, min_width, max_width} do
       {:zeroes, _, nil} -> Text.integer()
-      {:zeroes, min, max} -> choice(Enum.map(max..min//-1, &fixed_integer(&1)))
+      {:zeroes, min, max} -> choice(Enum.map(Range.new(max, min, -1), &fixed_integer(&1)))
       {:spaces, -1, nil} -> skip(spaces()) |> Text.integer()
       {:spaces, min, nil} -> skip(spaces()) |> fixed_integer(min)
-      {:spaces, _, max} -> skip(spaces()) |> choice(Enum.map(max..1//-1, &fixed_integer(&1)))
+      {:spaces, _, max} -> skip(spaces()) |> choice(Enum.map(Range.new(max, 1, -1), &fixed_integer(&1)))
       {_, -1, nil} -> Text.integer()
       {_, min, nil} -> fixed_integer(min)
-      {_, min, max} -> choice(Enum.map(max..min//-1, &fixed_integer(&1)))
+      {_, min, max} -> choice(Enum.map(Range.new(max, min, -1), &fixed_integer(&1)))
     end
   end
 end


### PR DESCRIPTION
### Summary of changes

With recent versions of Elixir, a runtime warning comes up when using `first..last` notation when `first` is greater than `last`.
Example:
```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (tzdata 1.1.2) lib/tzdata/util.ex:99: Tzdata.Util.first_weekday_of_month_at_most/4
  (tzdata 1.1.2) lib/tzdata/period_builder.ex:356: anonymous fn/2 in Tzdata.PeriodBuilder.sort_rules_by_time/2
  (elixir 1.18.2) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  (tzdata 1.1.2) lib/tzdata/period_builder.ex:356: Tzdata.PeriodBuilder.sort_rules_by_time/2
  (tzdata 1.1.2) lib/tzdata/period_builder.ex:228: Tzdata.PeriodBuilder.calc_rule_periods/8
```

This change simply uses the explicit Range.new/3 operator specifying -1 for the step.

Related doc:
    https://hexdocs.pm/elixir/1.15.0/Range.html#new/2

Because of the simplicity and small size of this change, I thought it appropriate to merge into @nathany-copia 's excellent ongoing work to bring Timex up to date.